### PR TITLE
Generalise selections for map operations

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -2,7 +2,7 @@ use std::io::{Write, Error};
 use std::mem;
 use byteorder::{LittleEndian as LE, WriteBytesExt};
 
-use selection::Rectangle;
+use selection::Selection;
 
 pub struct MapTile {
     terrain: u8,
@@ -111,24 +111,23 @@ impl Map {
         }
     }
 
-    pub fn flatten(&mut self, part: Rectangle) {
+    pub fn flatten<T: Selection>(&mut self, selection: T) {
         let mut weighted_elevation = 0;
-        for x in part.x..(part.x + part.width) {
-            for y in part.y..(part.y + part.height) {
-                match self.tile_at(x, y) {
-                    Some(tile) => weighted_elevation += tile.elevation as u32,
-                    None => ()
-                }
+        let mut tiles = 0;
+        for coord in selection.coordinates() {
+            match self.tile_at(coord.x, coord.y) {
+                Some(tile) => {
+                    tiles += 1;
+                    weighted_elevation += tile.elevation as u32;
+                },
+                None => ()
             }
         }
-        let tiles = part.width * part.height;
-        self.flatten_to(part, (weighted_elevation / tiles) as u8)
+        self.flatten_to(selection, (weighted_elevation / tiles) as u8)
     }
-    pub fn flatten_to(&mut self, part: Rectangle, elevation: u8) {
-        for x in part.x..(part.x + part.width) {
-            for y in part.y..(part.y + part.height) {
-                self.elevate(x, y, elevation)
-            }
+    pub fn flatten_to<T: Selection>(&mut self, selection: T, elevation: u8) {
+        for coord in selection.coordinates() {
+            self.elevate(coord.x, coord.y, elevation)
         }
     }
 

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -1,3 +1,14 @@
+use std::iter::Iterator;
+
+pub struct Coordinate {
+    pub x: u32,
+    pub y: u32
+}
+
+pub trait Selection {
+    fn coordinates(&self) -> Vec<Coordinate>;
+}
+
 pub struct Rectangle {
     pub x: u32,
     pub y: u32,
@@ -13,5 +24,17 @@ impl Rectangle {
             width: width,
             height: height
         }
+    }
+}
+
+impl Selection for Rectangle {
+    fn coordinates(&self) -> Vec<Coordinate> {
+        let mut tiles = vec![];
+        for x in self.x..(self.x + self.width) {
+            for y in self.y..(self.y + self.height) {
+                tiles.push(Coordinate { x: x, y: y });
+            }
+        }
+        tiles
     }
 }

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -1,14 +1,45 @@
 use std::iter::Iterator;
 
+#[derive(Clone, Copy, Debug)]
 pub struct Coordinate {
     pub x: u32,
     pub y: u32
 }
 
-pub trait Selection {
+pub trait Selection : Sized + Copy {
     fn coordinates(&self) -> Vec<Coordinate>;
+
+    fn and<B: Selection>(&self, b: B) -> AndSelection<Self, B> {
+        AndSelection::new(*self, b)
+    }
 }
 
+#[derive(Clone, Copy, Debug)]
+struct AndSelection<A: Selection, B: Selection> {
+    a: A,
+    b: B
+}
+
+impl<A: Selection, B: Selection> AndSelection<A, B> {
+    fn new(a: A, b: B) -> AndSelection<A, B> {
+        AndSelection { a: a, b: b }
+    }
+}
+
+impl<A: Selection, B: Selection> Selection for AndSelection<A, B> {
+    fn coordinates(&self) -> Vec<Coordinate> {
+        let mut coords = vec![];
+        for coord in self.a.coordinates() {
+            coords.push(coord);
+        }
+        for coord in self.b.coordinates() {
+            coords.push(coord);
+        }
+        coords
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
 pub struct Rectangle {
     pub x: u32,
     pub y: u32,

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -6,6 +6,12 @@ pub struct Coordinate {
     pub y: u32
 }
 
+impl Coordinate {
+    pub fn new(x: u32, y: u32) -> Coordinate {
+        Coordinate { x: x, y: y }
+    }
+}
+
 pub trait Selection : Sized + Copy {
     fn coordinates(&self) -> Vec<Coordinate>;
 

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -14,6 +14,12 @@ pub trait Selection : Sized + Copy {
     }
 }
 
+impl Selection for Coordinate {
+    fn coordinates(&self) -> Vec<Coordinate> {
+        vec![*self]
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 struct AndSelection<A: Selection, B: Selection> {
     a: A,

--- a/src/world.rs
+++ b/src/world.rs
@@ -1,6 +1,6 @@
 use consts::{Terrain, MapSize};
 use map::{MapTile, Map};
-use selection::Rectangle;
+use selection::{Rectangle, Selection};
 
 pub struct World {
     pub base_terrain: Terrain,
@@ -33,13 +33,11 @@ impl World {
                 ));
             }
         }
-        let rect = Rectangle {
-            x: 20,
-            y: 20,
-            width: 20,
-            height: 20
-        };
-        map.flatten_to(rect, 4);
+        let selection = Rectangle::new(20, 20, 20, 20).and(Rectangle::new(5, 5, 5, 5));
+        map.flatten_to(selection, 4);
+
+        map.elevate(30, 30, 2);
+
         map
     }
 }


### PR DESCRIPTION
Implement a `Selection` trait with a `coordinates` method that returns all the tile coordinates in the selection.
